### PR TITLE
feat: load OpenAI API key from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ YOUR_CHAT_ID=-1001294162183
 MAX_ID=741542965
 ADMIN_IDS=741542965
 RAPIDAPI_KEY=your_rapidapi_key_here
+OPENAI_API_KEY=your_openai_api_key_here
 
 # Database Config
 DB_HOST=localhost

--- a/.env.template
+++ b/.env.template
@@ -3,6 +3,7 @@ BOT_TOKEN=your_telegram_bot_token_here
 
 # Google Gemini Configuration (required for trivia)
 GEMINI_API_KEY=your_gemini_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
 
 # Database Configuration
 DATABASE_URL=sqlite:///bot.db

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install -r requirements.txt
 # Copy the environment template
 cp .env.example .env
 
-# Edit .env with your actual credentials
+# Edit .env with your actual credentials (add OPENAI_API_KEY if using AI features)
 # DO NOT use the example values in production!
 ```
 
@@ -61,7 +61,7 @@ cp .env.example .env
 #### External APIs (Optional)
 - `SPOTIFY_CLIENT_ID` - Spotify API client ID
 - `SPOTIFY_CLIENT_SECRET` - Spotify API client secret
-- `OPENAI_API_KEY` - OpenAI API key for AI features
+- `OPENAI_API_KEY` - OpenAI API key for AI features (loaded from .env)
 
 ### 4. Database Setup
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -133,7 +133,7 @@ tg-bot/
 2. **Set up environment:**
    ```bash
    cp .env.example .env
-   # Edit .env with your credentials
+   # Edit .env with your credentials (include OPENAI_API_KEY for AI features)
    ```
 
 3. **Run the bot:**

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -22,6 +22,7 @@ class Settings:
     
     # AI configuration
     GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
+    OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
     
     # Spotify configuration
     SPOTIFY_CLIENT_ID = os.getenv('SPOTIFY_CLIENT_ID')

--- a/src/services/crypto_service.py
+++ b/src/services/crypto_service.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from openpyxl import load_workbook
 from typing import Dict, Optional
 
@@ -13,28 +14,29 @@ class CryptoService:
         self.crypto_module = crypto_module
     
     def decrypt_and_load_config(self, encrypted_file: str, decrypted_file: str) -> Dict[str, Optional[str]]:
-        """Decrypt file and load configuration from Excel."""
+        """Decrypt file and load configuration from Excel and environment."""
+        openai_api_key = os.getenv("OPENAI_API_KEY")
         try:
             # Decrypt the file
             self.crypto_module.decrypt_file(encrypted_file, decrypted_file)
-            
+
             # Load workbook
             workbook = load_workbook(filename=decrypted_file)
             sheet = workbook.active
-            
-            # Read API keys from cells
+
+            # Read API keys
             config = {
-                'openai_api_key': sheet['A1'].value,
+                'openai_api_key': openai_api_key,
                 'google_api_key': sheet['A2'].value
             }
-            
+
             logger.info("Configuration loaded successfully from decrypted file")
             return config
-            
+
         except Exception as e:
             logger.error(f"Error loading encrypted config: {str(e)}")
             return {
-                'openai_api_key': None,
+                'openai_api_key': openai_api_key,
                 'google_api_key': None
             }
     


### PR DESCRIPTION
## Summary
- expose `OPENAI_API_KEY` in env templates
- load `OPENAI_API_KEY` via settings and crypto service
- document OpenAI key setup in README and docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a49fbbaec8832f91e0a8f4a5639c19