### PR TITLE
Add OpenAI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ pydantic-core==2.23.4
 tqdm==4.66.1
 cryptography==43.0.1
 pycparser==2.21
+openai>=1.0.0
 openpyxl==3.1.2
 spotdl~=4.2.11
 APScheduler~=3.10.4


### PR DESCRIPTION
## Summary
- add OpenAI to main requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a49fe12000832fbf86b46d068b54d0