### PR TITLE
Load BTC price bot token from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
 # Telegram Config
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 MEMORY_BOT_TOKEN=your_memory_bot_token_here
+BTC_BOT_TOKEN=your_btc_bot_token_here
 YOUR_CHAT_ID=-1001294162183
 MAX_ID=741542965
 ADMIN_IDS=741542965

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ cp .env.example .env
 #### Bot Tokens
 - `TELEGRAM_BOT_TOKEN` - Main bot token from @BotFather
 - `MEMORY_BOT_TOKEN` - Memory bot token from @BotFather
+- `BTC_BOT_TOKEN` - Token for BTC price bot from @BotFather
 
 #### Database Configuration
 - `DB_HOST` - Database host (default: localhost)

--- a/scripts/btc.py
+++ b/scripts/btc.py
@@ -1,3 +1,4 @@
+import os
 import telebot
 import requests
 import time
@@ -5,9 +6,14 @@ import json
 from threading import Thread, Event, Lock
 from collections import deque
 import random
+from dotenv import load_dotenv
 
 # Initialize bot
-bot = telebot.TeleBot('7460498911:AAGbjXFhXOOnXIr46dooSq_apvH-OM4HMP4')
+load_dotenv()
+bot_token = os.getenv("BTC_BOT_TOKEN")
+if not bot_token:
+    raise ValueError("BTC_BOT_TOKEN is not set in the environment")
+bot = telebot.TeleBot(bot_token)
 
 # API Configuration
 API_KEYS = [


### PR DESCRIPTION
## Summary
- read BTC bot token from `.env` instead of hardcoding
- document new `BTC_BOT_TOKEN` variable in environment example and README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a63e988c832fa94a852bd88626fa