### PR TITLE
Analyze GIFs sent as replies to the bot

### DIFF
--- a/src/handlers/moltbot_handlers.py
+++ b/src/handlers/moltbot_handlers.py
@@ -1857,6 +1857,19 @@ class MoltbotHandlers:
                 except Exception as e:
                     logger.warning(f"MoltBot: reply photo analysis failed: {e}")
 
+            # New GIF in reply to bot — analyze via Gemini (Telegram GIFs can't carry a caption+mention, so this is the main entry point)
+            elif message.animation:
+                try:
+                    file = await self.bot.get_file(message.animation.file_id)
+                    bio = await self.bot.download_file(file.file_path)
+                    animation_bytes = bio.read()
+                    animation_analysis = await asyncio.to_thread(
+                        self._analyze_animation_with_gemini, animation_bytes, user_text
+                    )
+                    user_text = f"[Гифка: {animation_analysis}]\n{user_text}" if user_text else f"[Гифка: {animation_analysis}]"
+                except Exception as e:
+                    logger.warning(f"MoltBot: reply animation analysis failed: {e}")
+
             # If replying to a bot message that was about a photo, add context note (no re-analysis)
             replied_msg_id = message.reply_to_message.message_id
             photo_file_id = self._photo_context.get(replied_msg_id)


### PR DESCRIPTION
## Summary
- Follow-up to #6. Max pointed out Telegram doesn't let you attach a caption to a GIF the normal way, so the @-mention-in-caption entry point (`handle_animation_mention`) basically never fires in practice — the real-world flow is replying to a bot message with a GIF.
- `handle_reply_to_bot` already had this pattern for photos; added an `elif message.animation` branch that downloads the gif and runs it through `_analyze_animation_with_gemini` (added in #6), folding the result into `user_text` as `[Гифка: ...]` the same way photos do.

## Test plan
- [x] `python3 -m py_compile src/handlers/moltbot_handlers.py`
- [ ] Reply to a bot message with a GIF in a group chat, confirm the bot's answer references the GIF content
- [ ] Confirm normal photo-reply and @-mention-caption-gif paths still work unaffected