### PR TITLE
Log full Gemini image/gif analysis instead of truncating

### DIFF
--- a/src/handlers/moltbot_handlers.py
+++ b/src/handlers/moltbot_handlers.py
@@ -339,7 +339,7 @@ class MoltbotHandlers:
                 prompt,
             ])
             result = response.text
-            logger.info(f"MoltBot: Gemini image analysis: {result[:200]}")
+            logger.info(f"MoltBot: Gemini image analysis: {result}")
             return result
         except Exception as e:
             logger.error(f"MoltBot: Gemini image analysis failed: {e}")
@@ -358,7 +358,7 @@ class MoltbotHandlers:
                 prompt,
             ])
             result = response.text
-            logger.info(f"MoltBot: Gemini animation analysis: {result[:200]}")
+            logger.info(f"MoltBot: Gemini animation analysis: {result}")
             return result
         except Exception as e:
             logger.error(f"MoltBot: Gemini animation analysis failed: {e}")


### PR DESCRIPTION
## Summary
- `_analyze_image_with_gemini` / `_analyze_animation_with_gemini` logged only `result[:200]`, so Max only ever saw the first 200 chars of what Gemini actually said about a photo/gif in the logs.
- Removed the truncation — logs now contain the full analysis text.

## Test plan
- [x] `python3 -m py_compile src/handlers/moltbot_handlers.py`
- [ ] Send a photo/gif and confirm the full Gemini description shows up in main-bot.log